### PR TITLE
Add support for HTTP compression where available, enabled by default.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 Revision history for Perl extension Net::Amazon:
+0.62 (11/07/2011)
+   (dc) Add support for HTTP compression where available, enabled by default.
+
 0.61 (10/28/2011)
    (cb) rt 71937; Amazon now requires an Associate Tag, so enforce usage.
    (cb) The ListLookup operation has been removed from the WSDL (from 2010!),

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ WriteMakefile1(
                              URI            => 0,
                              Digest::SHA    => 0,
                              URI::Escape    => 0,
+                             HTTP::Message  => 0,
                            }, # e.g., Module::Name => 1.1
     ABSTRACT_FROM => 'lib/Net/Amazon.pm',
     AUTHOR => 'Mike <m@perlmeister.com>',

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 ######################################################################
-    Net::Amazon 0.61
+    Net::Amazon 0.62
 ######################################################################
 NAME
     Net::Amazon - Framework for accessing amazon.com via REST
@@ -125,6 +125,13 @@ CACHING
 
             # Return a cached value, 'undef' if it doesn't exist
         $cache->get($key);
+
+
+COMPRESSION
+
+By default "Net::Amazon" will attempt to use HTTP compression if the
+"Compress::Zlib" module is available. Pass "compress => 0" to "->new()" to
+disable this feature.
 
 PROXY SETTINGS
     "Net::Amazon" uses "LWP::UserAgent" under the hood to send web requests
@@ -385,6 +392,7 @@ AUTHOR
         Brian Hirt <bhirt@mobygames.com>
         Dan Kreft <dan@kreft.net>
         Dan Sully <daniel@electricrain.com>
+        Dave Cardwell <http://davecardwell.co.uk/>
         Jackie Hamilton <kira@cgi101.com>
         Konstantin Gredeskoul <kig@get.topica.com>
         Lance Cleveland <lancec@proactivewm.com>


### PR DESCRIPTION
Amazon’s web service implements HTTP compression so I have added support for this to Net::Amazon.

I have enabled it by default, but if you would prefer it to be opt-in let me know and I will make the tweaks to `->new()` and the documentation.

If you do not wish to add support for compression directly into Net::Amazon, please consider keeping my changes where I have modified `$resp->content()` to `$resp->decoded_content()` as this would still allow a user to do the following:

``` perl
my $ua = LWP::UserAgent->new();
$ua->default_header('Accept-Encoding' => [ HTTP::Message::decodable() ]);

my $na = Net::Amazon->new(
    ua => $ua,
    # ...
);
```
