### PR TITLE
make BrowseNode force array too

### DIFF
--- a/lib/Net/Amazon/Property.pm
+++ b/lib/Net/Amazon/Property.pm
@@ -106,6 +106,9 @@ sub new {
     }
 
     my @browse_nodes;
+    if (ref $options{xmlref}->{BrowseNodes}->{BrowseNode} eq 'HASH') {
+        $options{xmlref}->{BrowseNodes}->{BrowseNode} = [ $options{xmlref}->{BrowseNodes}->{BrowseNode} ];
+    }
     if (ref $options{xmlref}->{BrowseNodes}->{BrowseNode} eq 'ARRAY') {
         for my $bn (@{$options{xmlref}->{BrowseNodes}->{BrowseNode}}) {
             push @browse_nodes, $bn->{Name};     

--- a/lib/Net/Amazon/Property.pm
+++ b/lib/Net/Amazon/Property.pm
@@ -181,7 +181,7 @@ sub factory {
 
     #DEBUG(sub {"factory xmlref=" . Data::Dumper::Dumper($xmlref)});
 
-    my $catalog = $xmlref->{ItemAttributes}->{ProductGroup};
+    my $catalog = $xmlref->{ItemAttributes}->{ProductGroup} || '';
     my $obj;
 
     if(0) {

--- a/lib/Net/Amazon/Response.pm
+++ b/lib/Net/Amazon/Response.pm
@@ -11,7 +11,7 @@ use XML::Simple;
 use Log::Log4perl qw(:easy get_logger);
 
 our @FORCE_ARRAY_FIELDS = qw(Author Artist Creator Director Disc
-Review EditorialReview SimilarProduct Track BrowseNode);
+Review EditorialReview SimilarProduct Track);
 
 __PACKAGE__->make_accessor($_) for qw(
   status messages items xmlref total_results);

--- a/lib/Net/Amazon/Response.pm
+++ b/lib/Net/Amazon/Response.pm
@@ -11,7 +11,7 @@ use XML::Simple;
 use Log::Log4perl qw(:easy get_logger);
 
 our @FORCE_ARRAY_FIELDS = qw(Author Artist Creator Director Disc
-Review EditorialReview SimilarProduct Track);
+Review EditorialReview SimilarProduct Track BrowseNode);
 
 __PACKAGE__->make_accessor($_) for qw(
   status messages items xmlref total_results);


### PR DESCRIPTION
sample XML returned as

```
                   'xmlref' => {
                             'SalesRank' => '94244',
                             'ASIN' => 'B003F80IME',
                             'ItemAttributes' => {},
                             'SimilarProducts' => {
                                                    'SimilarProduct' => []
                                                  },
                             'BrowseNodes' => {
                                                'BrowseNode' => {
                                                                'BrowseNodeId' => '166099011',
                                                                'Ancestors' => {
                                                                               'BrowseNode' => {
                                                                                               'BrowseNodeId' 
```

Note here BrowseNode returns {} since it has only one element.

and in Property.pm
if (ref $options{xmlref}->{BrowseNodes}->{BrowseNode} eq 'ARRAY') {

it will just ignore it.

Thanks.
