### PR TITLE
Update README - Remove note about POD errors

### DIFF
--- a/README
+++ b/README
@@ -414,11 +414,3 @@ COPYRIGHT AND LICENSE
 
     This library is free software; you can redistribute it and/or modify it
     under the same terms as Perl itself.
-
-POD ERRORS
-    Hey! The above document had some coding errors, which are explained
-    below:
-
-    Around line 748:
-        You forgot a '=back' before '=head1'
-


### PR DESCRIPTION
Remove note about POD errors:

POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

```
Around line 748:
    You forgot a '=back' before '=head1'
```
