### PR TITLE
Added SalePrice accessor

### DIFF
--- a/lib/Net/Amazon/Property.pm
+++ b/lib/Net/Amazon/Property.pm
@@ -37,6 +37,7 @@ our %DEFAULT_ATTRIBUTES_XPATH = (
     MediumImageWidth => [qw(MediumImage Width content)],
     MediumImageHeight => [qw(MediumImage Height content)],
     OurPrice => [qw(Offers Offer OfferListing Price FormattedPrice)],
+    SalePrice => [qw(Offers Offer OfferListing SalePrice FormattedPrice)],
     ImageUrlSmall => [qw(SmallImage URL)],
     SmallImageUrl => [qw(SmallImage URL)],
     SmallImageWidth => [qw(SmallImage Width content)],
@@ -154,7 +155,9 @@ sub _best_effort_price {
     my($self) = @_;
 
     my $price;
-    if ($self->OurPrice()) {
+    if( $self->SalePrice()) {
+        $price = $self->SalePrice();
+    } elsif ($self->OurPrice()) {
         $price = $self->OurPrice();
     } elsif ($self->ThirdPartyNewPrice()) {
         $price = $self->ThirdPartyNewPrice();
@@ -339,6 +342,10 @@ List price of the item
 =item OurPrice()
 
 Amazon price of the item
+
+=item SalePrice()
+
+Sale price of the item
 
 =item UsedPrice()
 


### PR DESCRIPTION
Amazon sometimes has special offers which they hide in
Offers/Offer/OfferListing/SalePrice/Amount rather than
Offers/Offer/OfferListing/Price/Amount.

OurPrice then lists the "regular" price, while you probably
want the sale price. So to get the current price, use something
like:

   my $price = $prop->SalePrice() ? $prop->SalePrice() : $prop->OurPrice();

Maybe OurPrice should even be patched to display the SalePrice
when it exists and the Price value when it doesn't, but I'll
leave that up to the maintainer of the module.
