### PR TITLE
Fix test failures due to require() needing a non-@INC path

### DIFF
--- a/t/010Artist.t
+++ b/t/010Artist.t
@@ -5,6 +5,7 @@ use warnings;
 use strict;
 
 use Test::More tests => 23;
+use File::Spec::Functions qw( rel2abs );
 BEGIN { use_ok('Net::Amazon') };
 
 #use Log::Log4perl qw(:easy);
@@ -16,7 +17,7 @@ use Net::Amazon::Request::Artist;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/011Locale.t
+++ b/t/011Locale.t
@@ -8,12 +8,13 @@ use strict;
 
 use Net::Amazon;
 use Net::Amazon::Request::ASIN;
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 5;
 
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/012Keyword.t
+++ b/t/012Keyword.t
@@ -9,12 +9,13 @@ use strict;
 use Net::Amazon;
 use Net::Amazon::Property;
 use Net::Amazon::Request::Keyword;
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 12;
 
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/013Seller.t
+++ b/t/013Seller.t
@@ -5,6 +5,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 25;
 use Net::Amazon;
 use Net::Amazon::Request::Seller;
@@ -14,7 +15,7 @@ use Net::Amazon::Request::Seller;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/015Exchange.t
+++ b/t/015Exchange.t
@@ -5,6 +5,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 17;
 use Net::Amazon;
 use Net::Amazon::Result::Seller::Listing;
@@ -14,7 +15,7 @@ use Log::Log4perl qw(:easy);
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/017Author.t
+++ b/t/017Author.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 30;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::Author;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/018Actor.t
+++ b/t/018Actor.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 23;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::Actor;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/019MusicLabel.t
+++ b/t/019MusicLabel.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 14;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::MusicLabel;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/022Director.t
+++ b/t/022Director.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 23;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::Director;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/023Title.t
+++ b/t/023Title.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 4;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::Title;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/024signature.t
+++ b/t/024signature.t
@@ -6,6 +6,7 @@ use strict;
 use utf8; # Needed to include utf8 strings
 use Encode;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 6;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -19,7 +20,7 @@ use URI;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################

--- a/t/025cache.t
+++ b/t/025cache.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 6;
 BEGIN { use_ok('Net::Amazon'); use_ok('Log::Log4perl'); }
 
@@ -20,7 +21,7 @@ Log::Log4perl->easy_init({level => $ALL, file => ">>$log_file"});
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
 
 SKIP: {

--- a/t/027MP3Downloads.t
+++ b/t/027MP3Downloads.t
@@ -4,6 +4,7 @@
 use warnings;
 use strict;
 
+use File::Spec::Functions qw( rel2abs );
 use Test::More tests => 17;
 BEGIN { use_ok('Net::Amazon') };
 
@@ -16,7 +17,7 @@ use Net::Amazon::Request::MP3Downloads;
 ################################################################
 # Setup
 ################################################################
-  my($TESTDIR) = map { -d $_ ? $_ : () } qw(t ../t .);
+  my($TESTDIR) = map { -d $_ ? rel2abs($_) : () } qw(t ../t .);
   require "$TESTDIR/init.pl";
   my $CANNED = "$TESTDIR/canned";
 ################################################################


### PR DESCRIPTION
Due to '.' removal from @INC, "require t/foo" no longer loads ./t/foo

Bug: https://bugs.gentoo.org/617158
Bug: https://rt.cpan.org/Public/Bug/Display.html?id=121476